### PR TITLE
Update cluster template to display cluster details.

### DIFF
--- a/templates/asgard-cluster.eco
+++ b/templates/asgard-cluster.eco
@@ -2,6 +2,13 @@
   Cluster: <%= c.cluster %>
   AutoScalingGroups:<% for a in c.autoScalingGroups: %> <%= a %><% end %>
   <% end %>
+<% else if @data.length: %><% for c in @data: %>
+  AutoScalingGroupName: <%= c.autoScalingGroupName %>
+  Active: <%= not c.addingToLoadBalancerSuspended %>
+  CreatedTime: <%= c.createdTime %>
+  InstanceCount: <%= c.instances.length %>
+  Min/Des/Max: <%= c.minSize %>/<%= c.desiredCapacity %>/<%= c.maxSize %>
+  <% end %>
 <% else if @data[0].class: %><% for c in @data: %>
   Name: <%= c.autoScalingGroupName %>
   Instances (current/max): <%= c.instances.length %>/<%= c.maxSize %>
@@ -13,4 +20,3 @@
 <% else: %>
   Unknown response (This is probably a hubot-asgard bug).
 <% end %>
-


### PR DESCRIPTION
Greetings! I noticed an issue when using the `hubot-asgard` script's `cluster` command today (note that `HUBOT_ASGARD_DEBUG` mode is enabled):

```
Hubot> asgard cluster trusty_web
Hubot> [ { addingToLoadBalancerSuspended: true,
    autoScalingGroupName: 'trusty_web-v004',
    availabilityZones: [ 'us-east-1a', 'us-east-1b' ],
    createdTime: '2014-08-04T20:50:46Z',
    defaultCooldown: 300,
    desiredCapacity: 0,
    expirationDurationString: null,
    expirationTime: null,
    healthCheckGracePeriod: 0,
    healthCheckType: 
     { enumType: 'com.netflix.asgard.model.AutoScalingGroupHealthCheckType',
       name: 'EC2' },
    instances: [],
    launchConfigurationName: 'trusty_web-v004-20140804205045',
    launchingSuspended: true,
    loadBalancerNames: [ 'trusty-web' ],
    maxSize: 0,
    minSize: 0,
    mostCommonAppVersion: null,
    scalingPolicies: [],
    statesToInstanceList: {},
    status: null,
    suspendedPrimaryProcessTypes: [ [Object], [Object] ],
    suspendedProcessTypes: [ [Object], [Object], [Object] ],
    tags: [],
    terminatingSuspended: true,
    terminationPolicies: [ 'Default' ],
    variables: {},
    vpcZoneIdentifier: null,
    zoneRebalancingSuspended: false } ]

  Unknown response (This is probably a hubot-asgard bug).
```

It seems the template didn't have an `else if` block that can handle this JSON structure for clusters, so I've added a patch to make it work :+1: 

```
Hubot> asgard cluster trusty_web
Hubot> [ { addingToLoadBalancerSuspended: true,
    autoScalingGroupName: 'trusty_web-v004',
    availabilityZones: [ 'us-east-1a', 'us-east-1b' ],
    createdTime: '2014-08-04T20:50:46Z',
    defaultCooldown: 300,
    desiredCapacity: 0,
    expirationDurationString: null,
    expirationTime: null,
    healthCheckGracePeriod: 0,
    healthCheckType: 
     { enumType: 'com.netflix.asgard.model.AutoScalingGroupHealthCheckType',
       name: 'EC2' },
    instances: [],
    launchConfigurationName: 'trusty_web-v004-20140804205045',
    launchingSuspended: true,
    loadBalancerNames: [ 'trusty-web' ],
    maxSize: 0,
    minSize: 0,
    mostCommonAppVersion: null,
    scalingPolicies: [],
    statesToInstanceList: {},
    status: null,
    suspendedPrimaryProcessTypes: [ [Object], [Object] ],
    suspendedProcessTypes: [ [Object], [Object], [Object] ],
    tags: [],
    terminatingSuspended: true,
    terminationPolicies: [ 'Default' ],
    variables: {},
    vpcZoneIdentifier: null,
    zoneRebalancingSuspended: false } ]

  AutoScalingGroupName: trusty_web-v004
  Active: false
  CreatedTime: 2014-08-04T20:50:46Z
  InstanceCount: 0
  Min/Des/Max: 0/0/0
```

Feel free to let me know if you have any questions or concerns! Thanks in advance :smile: 
